### PR TITLE
Update baby example to be smaller

### DIFF
--- a/content/03-BabyAFQ.ipynb
+++ b/content/03-BabyAFQ.ipynb
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viz = myafq.export(\"profiles\")"
+    "viz = myafq.export(\"all_bundles_figure\")"
    ]
   },
   {

--- a/content/07-Custom-Bundle.ipynb
+++ b/content/07-Custom-Bundle.ipynb
@@ -69,41 +69,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec4caddf",
-   "metadata": {},
-   "source": [
-    "## Get ROIs and save to disk\n",
-    "\n",
-    "We download the ROI files from the MATLAB AFQ website and save them locally.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0da08036",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "roi_urls = [\n",
-    "    'https://github.com/yeatmanlab/AFQ/raw/c762ca4c393f2105d4f444c44d9e4b4702f0a646/SLF123/ROIs/MFgL.nii.gz',\n",
-    "    'https://github.com/yeatmanlab/AFQ/raw/c762ca4c393f2105d4f444c44d9e4b4702f0a646/SLF123/ROIs/MFgR.nii.gz',\n",
-    "    'https://github.com/yeatmanlab/AFQ/raw/c762ca4c393f2105d4f444c44d9e4b4702f0a646/SLF123/ROIs/PaL.nii.gz',\n",
-    "    'https://github.com/yeatmanlab/AFQ/raw/c762ca4c393f2105d4f444c44d9e4b4702f0a646/SLF123/ROIs/PaR.nii.gz',\n",
-    "    'https://github.com/yeatmanlab/AFQ/raw/c762ca4c393f2105d4f444c44d9e4b4702f0a646/SLF123/ROIs/SFgR.nii.gz',\n",
-    "    'https://github.com/yeatmanlab/AFQ/raw/c762ca4c393f2105d4f444c44d9e4b4702f0a646/SLF123/ROIs/SFgL.nii.gz'\n",
-    "]\n",
-    "\n",
-    "template_dir = op.join(home, \"data_\", \"tractometry\", 'SLF_ROIs')\n",
-    "os.makedirs(template_dir, exist_ok=True)\n",
-    "\n",
-    "for roi_url in roi_urls:\n",
-    "    wget.download(roi_url, template_dir)\n",
-    "\n",
-    "templates_afq = afd.read_templates(as_img=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "67ac80bf",
    "metadata": {},
    "source": [
@@ -119,6 +84,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "template_dir = op.join(afq_home, 'SLF_ROIs')\n",
+    "templates_afq = afd.read_templates(as_img=False)\n",
+    "\n",
+    "# You can provide paths to the ROIs in the \"include\" and \"exclude\" keys of the bundle definition\n",
     "bundles = abd.BundleDict({\n",
     "    \"L_SLF1\": {\n",
     "        \"include\": [template_dir + '/SFgL.nii.gz', template_dir + '/PaL.nii.gz'],\n",

--- a/content/09-Ray-MSMT.ipynb
+++ b/content/09-Ray-MSMT.ipynb
@@ -39,24 +39,25 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
+    "import os.path as op\n",
     "import numpy as np\n",
     "\n",
     "import AFQ.data.fetch as afd\n",
     "\n",
     "from dipy.core.gradients import gradient_table, unique_bvals_tolerance\n",
     "from dipy.data import get_sphere\n",
-    "from dipy.denoise.localpca import mppca\n",
     "import dipy.direction.peaks as dp\n",
     "from dipy.io.gradients import read_bvals_bvecs\n",
     "from dipy.io.image import load_nifti\n",
     "from dipy.reconst.mcsd import (\n",
     "    MultiShellDeconvModel,\n",
-    "    auto_response_msmt,\n",
     "    mask_for_response_msmt,\n",
     "    multi_shell_fiber_response,\n",
     "    response_from_mask_msmt,\n",
     ")\n",
-    "import dipy.reconst.shm as shm"
+    "import dipy.reconst.shm as shm\n",
+    "from dipy.segment.tissue import TissueClassifierHMRF\n",
+    "from dipy.segment.mask import median_otsu"
    ]
   },
   {
@@ -148,7 +149,7 @@
     ")\n",
     "ap = shm.anisotropic_power(peaks.shm_coeff)\n",
     "plt.matshow(np.rot90(ap[:, :, 50]), cmap=plt.cm.bone)\n",
-    "plt.show(\"anisotropic_power_map.png\")"
+    "plt.show()"
    ]
   },
   {
@@ -268,7 +269,7 @@
     ")\n",
     "\n",
     "mcsd_model = MultiShellDeconvModel(gtab, response_mcsd)\n",
-    "mcsd_fit = mcsd_model.fit(data[:, :, 50:60], engine=\"ray\")"
+    "mcsd_fit = mcsd_model.fit(data[:, :, 50], engine=\"ray\") # Using a subset of the data for speed in this example"
    ]
   },
   {
@@ -283,8 +284,17 @@
    "outputs": [],
    "source": [
     "ap = shm.anisotropic_power(mcsd_fit.shm_coeff)\n",
-    "plt.matshow(np.rot90(ap[:, :, 0]), cmap=plt.cm.bone)\n",
-    "plt.show(\"anisotropic_power_map.png\")\n",
+    "plt.matshow(np.rot90(ap[:, :]), cmap=plt.cm.bone)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01aa0109",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.close()"
    ]
   },

--- a/content/download_data.py
+++ b/content/download_data.py
@@ -46,7 +46,7 @@ def download_data():
 
 
 if not op.exists(tracometry_zip_f):
-    figshare_path = "https://figshare.com/ndownloader/files/51919394"
+    figshare_path = "https://figshare.com/ndownloader/files/52115198"
     with requests.get(figshare_path, stream=True) as response:
         response.raise_for_status()
 
@@ -78,14 +78,3 @@ tflow.get('MNI152NLin2009cAsym',
           suffix='mask')
 
 download_data()
-
-
-baby_zip = op.join(tractometry_dir, "baby_example.zip")
-
-if not op.exists(baby_zip):
-    print("Downloading processed pediatric data; this could take a while...")
-    wget.download("https://figshare.com/ndownloader/files/38053692", baby_zip)
-    baby_example_folder = op.join(tractometry_dir, "baby_example")
-    if not op.exists(baby_example_folder):
-        with zipfile.ZipFile(baby_zip, 'r') as zip_ref:
-            zip_ref.extractall(baby_example_folder)


### PR DESCRIPTION
Relies on https://github.com/tractometry/pyAFQ/pull/54 and https://github.com/tractometry/pyAFQ/pull/53

Moves baby data into big ZIP and reduces its size using scil and trx
Also adds minor fixes to examples 09 and 07